### PR TITLE
Run jupyter nbclassic -h on CI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -53,6 +53,9 @@ jobs:
     #     cd jupyter_server
     #     pip install -e .
     #     cd ../nbclassic
+    - name: Run the help command
+      run: |
+        jupyter nbclassic -h
     - name: Test with pytest
       run: |
         pytest -vv --cov nbclassic --cov-report term-missing:skip-covered


### PR DESCRIPTION
As a way to check if the same error can be reproduced:

https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=214523&view=logs&j=10bda42a-d420-5c28-a43f-bc4e66405e5c&t=bef775d0-a1a2-55a3-9721-17147029baf0&l=885

```
[E 2020-09-25 17:56:40.630 NotebookApp] Failed collecting help-message for alias 'transport', due to: 'KernelManager.transport'
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.7.9/x64/bin/jupyter-nbclassic", line 11, in <module>
    load_entry_point('nbclassic', 'console_scripts', 'jupyter-nbclassic')()
  File "/home/runner/work/nbclassic/jupyter_server/jupyter_server/extension/application.py", line 444, in launch_instance
    _preparse_for_stopping_flags(cls, args)
  File "/home/runner/work/nbclassic/jupyter_server/jupyter_server/extension/application.py", line 69, in _preparse_for_stopping_flags
    app.print_help('--help-all' in interpreted_argv)
  File "/opt/hostedtoolcache/Python/3.7.9/x64/lib/python3.7/site-packages/traitlets/config/application.py", line 503, in print_help
    print('\n'.join(self.emit_help(classes=classes)))
  File "/opt/hostedtoolcache/Python/3.7.9/x64/lib/python3.7/site-packages/traitlets/config/application.py", line 514, in emit_help
    for l in self.emit_options_help():
  File "/opt/hostedtoolcache/Python/3.7.9/x64/lib/python3.7/site-packages/traitlets/config/application.py", line 463, in emit_options_help
    for l in self.emit_alias_help():
  File "/opt/hostedtoolcache/Python/3.7.9/x64/lib/python3.7/site-packages/traitlets/config/application.py", line 398, in emit_alias_help
    trait = cls.class_traits(config=True)[traitname]
KeyError: 'KernelManager.transport'
```