### PR TITLE
Ignore some traits in shim layer

### DIFF
--- a/nbclassic/notebookapp.py
+++ b/nbclassic/notebookapp.py
@@ -117,17 +117,27 @@ class NotebookApp(
     traits.NotebookAppTraits,
 ):
 
-    name = 'jupyter-nbclassic'
+    name = 'notebook'
     version = __version__
     description = _("""The Jupyter HTML Notebook.
 
     This launches a Tornado based HTML Notebook Server that serves up an HTML5/Javascript Notebook client.""")
 
-    name = 'nbclassic'
-
     aliases = aliases
     flags = flags
     extension_url = "/tree"
+
+    # Override the default open_Browser trait in ExtensionApp,
+    # setting it to True.
+    open_browser = Bool(
+        True,
+        help="""Whether to open in a browser after starting.
+        The specific browser used is platform dependent and
+        determined by the python standard library `webbrowser`
+        module, unless it is overridden using the --browser
+        (ServerApp.browser) configuration option.
+        """
+    ).tag(config=True)
 
     static_custom_path = List(Unicode(),
         help=_("""Path to search for custom.js, css""")
@@ -215,7 +225,7 @@ class NotebookApp(
         handlers.extend(load_handlers('nbclassic.tree.handlers'))
         handlers.extend(load_handlers('nbclassic.notebook.handlers'))
         handlers.extend(load_handlers('nbclassic.edit.handlers'))
-        
+
         # Add terminal handlers
         handlers.append(
             (r"/terminals/(\w+)", TerminalHandler)

--- a/nbclassic/shim.py
+++ b/nbclassic/shim.py
@@ -234,7 +234,6 @@ class NBClassicConfigShimMixin:
         # 3. Handle ExtensionApp traits.
         warning_msg = None
         for trait_name, trait_value in extapp_config.items():
-            if trait_name in IGNORED_TRAITS: continue
             in_extapp = trait_name in extapp_traits
             in_svapp = trait_name in svapp_traits
             in_nbapp = trait_name in nbapp_traits

--- a/nbclassic/shim.py
+++ b/nbclassic/shim.py
@@ -36,7 +36,7 @@ NBAPP_TO_SVAPP_SHIM_MSG = lambda trait_name: (
 
 EXTAPP_AND_NBAPP_AND_SVAPP_SHIM_MSG = lambda trait_name, extapp_name: (
     "'{trait_name}' is found in {extapp_name}, NotebookApp, "
-    "and ServerApp. This is a recent change."
+    "and ServerApp. This is a recent change. "
     "This config will only be set in {extapp_name}. "
     "Please check if you should also config these traits in "
     "NotebookApp and ServerApp for your purpose.".format(
@@ -47,7 +47,7 @@ EXTAPP_AND_NBAPP_AND_SVAPP_SHIM_MSG = lambda trait_name, extapp_name: (
 
 EXTAPP_AND_SVAPP_SHIM_MSG = lambda trait_name, extapp_name: (
     "'{trait_name}' is found in both {extapp_name} "
-    "and ServerApp. This is a recent change."
+    "and ServerApp. This is a recent change. "
     "This config will only be set in {extapp_name}. "
     "Please check if you should also config these traits in "
     "ServerApp for your purpose.".format(
@@ -58,7 +58,7 @@ EXTAPP_AND_SVAPP_SHIM_MSG = lambda trait_name, extapp_name: (
 
 EXTAPP_AND_NBAPP_SHIM_MSG = lambda trait_name, extapp_name: (
     "'{trait_name}' is found in both {extapp_name} "
-    "and NotebookApp. This is a recent change."
+    "and NotebookApp. This is a recent change. "
     "This config will only be set in {extapp_name}. "
     "Please check if you should also config these traits in "
     "NotebookApp for your purpose.".format(
@@ -70,7 +70,7 @@ EXTAPP_AND_NBAPP_SHIM_MSG = lambda trait_name, extapp_name: (
 NOT_EXTAPP_NBAPP_AND_SVAPP_SHIM_MSG = lambda trait_name, extapp_name: (
     "'{trait_name}' is not found in {extapp_name}, but "
     "it was found in both NotebookApp "
-    "and ServerApp. This is likely a recent change."
+    "and ServerApp. This is likely a recent change. "
     "This config will only be set in ServerApp. "
     "Please check if you should also config these traits in "
     "NotebookApp for your purpose.".format(
@@ -97,6 +97,9 @@ EXTAPP_TO_NBAPP_SHIM_MSG = lambda trait_name, extapp_name: (
     )
 )
 
+# A tuple of traits that shouldn't be shimmed or throw any
+# warnings of any kind.
+IGNORED_TRAITS = ("open_browser", "log_level", "log_format")
 
 
 class NBClassicConfigShimMixin:
@@ -128,7 +131,6 @@ class NBClassicConfigShimMixin:
     For a longer description on how individual traits are handled,
     read the docstring under `shim_config_from_notebook_to_jupyter_server`.
     """
-
 
     @wraps(JupyterApp.update_config)
     def update_config(self, config):
@@ -211,7 +213,10 @@ class NBClassicConfigShimMixin:
         for trait_name, trait_value in nbapp_config.items():
             in_svapp = trait_name in svapp_traits
             in_nbapp = trait_name in nbapp_traits
-            if in_svapp and in_nbapp:
+            if trait_name in IGNORED_TRAITS:
+                # Pass trait through without any warning message.
+                nbapp_config_shim.update({trait_name: trait_value})
+            elif in_svapp and in_nbapp:
                 warning_msg = NBAPP_AND_SVAPP_SHIM_MSG(trait_name)
                 nbapp_config_shim.update({trait_name: trait_value})
             elif in_svapp:
@@ -229,11 +234,14 @@ class NBClassicConfigShimMixin:
         # 3. Handle ExtensionApp traits.
         warning_msg = None
         for trait_name, trait_value in extapp_config.items():
+            if trait_name in IGNORED_TRAITS: continue
             in_extapp = trait_name in extapp_traits
             in_svapp = trait_name in svapp_traits
             in_nbapp = trait_name in nbapp_traits
-
-            if all([in_extapp, in_svapp, in_nbapp]):
+            if trait_name in IGNORED_TRAITS:
+                # Pass trait through without any warning message.
+                extapp_config_shim.update({trait_name: trait_value})
+            elif all([in_extapp, in_svapp, in_nbapp]):
                 warning_msg = EXTAPP_AND_NBAPP_AND_SVAPP_SHIM_MSG(
                     trait_name,
                     extapp_name

--- a/tests/shim/test_nbclassic.py
+++ b/tests/shim/test_nbclassic.py
@@ -16,7 +16,7 @@ def jp_server_config():
 
 @pytest.fixture
 def nbclassic(jp_serverapp):
-    return jp_serverapp.extension_manager.extension_points["nbclassic"].app
+    return jp_serverapp.extension_manager.extension_points["notebook"].app
 
 
 def list_test_params(param_input):


### PR DESCRIPTION
Adds a list of traits that should be ignored by nbclassic's shim layer.

- `open_browser` is now a trait of `jupyter_server`'s `ServerApp` and `ExtensionApp`. These traits must have the same name for backward-compatibility.
- `log_level` and `log_format` exist in `ServerApp`, `ExtensionApp`, and `NotebookApp`, and users need to be able to configure each one separately.

This PR also changes the name trait of nbclassic's `NotebookApp` to "`notebook`". This enables nbclassic to find the `jupyter_notebook_config.py`