### PR TITLE
Fix GitHub Actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jupyter Notebook as a Jupyter Server Extension
 
-![Testing nbclassic](https://github.com/Zsailer/nbclassic/workflows/Testing%20nbclassic/badge.svg)
+![Testing nbclassic](https://github.com/jupyterlab/nbclassic/workflows/Testing%20nbclassic/badge.svg)
 
 
 NBClassic runs the [Jupyter Notebook]((github.com/jupyter/notebook)) frontend on the Jupyter Server backend.


### PR DESCRIPTION
So the status is correctly reported:

![image](https://user-images.githubusercontent.com/591645/104563098-87731680-5649-11eb-82e2-13e0c48c049b.png)
