### PR TITLE
Add default_url trait to NotebookApp

### DIFF
--- a/nbclassic/notebookapp.py
+++ b/nbclassic/notebookapp.py
@@ -127,6 +127,8 @@ class NotebookApp(
     flags = flags
     extension_url = "/tree"
 
+    default_url = Unicode("/tree").tag(config=True)
+
     # Override the default open_Browser trait in ExtensionApp,
     # setting it to True.
     open_browser = Bool(

--- a/nbclassic/shim.py
+++ b/nbclassic/shim.py
@@ -99,7 +99,7 @@ EXTAPP_TO_NBAPP_SHIM_MSG = lambda trait_name, extapp_name: (
 
 # A tuple of traits that shouldn't be shimmed or throw any
 # warnings of any kind.
-IGNORED_TRAITS = ("open_browser", "log_level", "log_format")
+IGNORED_TRAITS = ("open_browser", "log_level", "log_format", "default_url")
 
 
 class NBClassicConfigShimMixin:


### PR DESCRIPTION
`default_url` was missing from the `NotebookApp` and needs be reinstated for backwards compatibility. This also updates the shim layer to ignore `default_url`.