### PR TITLE
Add a redirect handler to open non-notebook files from the cli

### DIFF
--- a/nbclassic/notebookapp.py
+++ b/nbclassic/notebookapp.py
@@ -14,6 +14,7 @@ import warnings
 import gettext
 
 from jinja2 import Environment, FileSystemLoader
+from tornado.web import RedirectHandler
 
 import notebook
 from notebook import (
@@ -218,6 +219,17 @@ class NotebookApp(
         """Load the (URL pattern, handler) tuples for each component."""
         # Order matters. The first handler to match the URL will handle the request.
         handlers = []
+
+        # Add a redirect from /notebooks to /edit
+        # for opening non-ipynb files in edit mode.
+        handlers.append(
+            (
+                rf"/({self.file_url_prefix})/(.*)\.(((?!ipynb)).*)",
+                RedirectHandler,
+                {"url": "/edit/{1}.{2}"}
+            )
+        )
+
         # load extra services specified by users before default handlers
         for service in self.settings['extra_services']:
             handlers.extend(load_handlers(service))

--- a/nbclassic/notebookapp.py
+++ b/nbclassic/notebookapp.py
@@ -224,9 +224,9 @@ class NotebookApp(
         # for opening non-ipynb files in edit mode.
         handlers.append(
             (
-                rf"/({self.file_url_prefix})/(.*)\.(((?!ipynb)).*)",
+                rf"/{self.file_url_prefix}/((?!.*\.ipynb($|\?)).*)",
                 RedirectHandler,
-                {"url": "/edit/{1}.{2}"}
+                {"url": "/edit/{0}"}
             )
         )
 

--- a/nbclassic/notebookapp.py
+++ b/nbclassic/notebookapp.py
@@ -127,6 +127,7 @@ class NotebookApp(
     aliases = aliases
     flags = flags
     extension_url = "/tree"
+    subcommands = {}
 
     # Override the default open_Browser trait in ExtensionApp,
     # setting it to True.

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup_args = dict(
     python_requires='>=3.6',
     include_package_data=True,
     install_requires = [
-        'jupyter_server~=1.1',
+        'jupyter_server~=1.4',
         'notebook<7',
     ],
     entry_points = {


### PR DESCRIPTION
This makes it possible to open non-notebook files from the cli, for example:

```bash
jupyter nbclassic setup.py
```

https://user-images.githubusercontent.com/591645/108713912-27f60980-7519-11eb-90e7-d70ba10e2c2e.mp4

