### PR TITLE
Fix deprecation warning when importing jupyter_server.transutils._

### DIFF
--- a/nbclassic/notebook/handlers.py
+++ b/nbclassic/notebook/handlers.py
@@ -22,7 +22,7 @@ from jupyter_server.utils import (
     url_escape,
     ensure_async
 )
-from jupyter_server.transutils import _
+from jupyter_server.transutils import _i18n
 
 
 def get_frontend_exporters():
@@ -52,7 +52,7 @@ def get_frontend_exporters():
 
         # Ensure export_from_notebook is explicitly defined & not inherited
         if ux_name is not None and ux_name != super_uxname:
-            display = _('{} ({})'.format(ux_name,
+            display = _i18n('{} ({})'.format(ux_name,
                                          exporter_instance.file_extension))
             frontend_exporters.append(ExporterInfo(name, display))
 
@@ -117,4 +117,3 @@ class NotebookHandler(ExtensionHandlerJinjaMixin, ExtensionHandlerMixin, Jupyter
 default_handlers = [
     (r"/notebooks%s" % path_regex, NotebookHandler),
 ]
-

--- a/nbclassic/notebookapp.py
+++ b/nbclassic/notebookapp.py
@@ -42,7 +42,7 @@ from jupyter_server.extension.application import (
 )
 
 from jupyter_server.log import log_request
-from jupyter_server.transutils import _
+from jupyter_server.transutils import _i18n
 from jupyter_server.serverapp import (
     ServerApp,
     random_ports,
@@ -71,7 +71,7 @@ flags = {}
 aliases = {}
 flags['no-browser']=(
     {'ServerApp' : {'open_browser' : False}},
-    _("Don't open the notebook in a browser after startup.")
+    _i18n("Don't open the notebook in a browser after startup.")
 )
 flags['no-mathjax']=(
     {'NotebookApp' : {'enable_mathjax' : False}},
@@ -87,7 +87,7 @@ flags['no-mathjax']=(
 
 flags['allow-root']=(
     {'ServerApp' : {'allow_root' : True}},
-    _("Allow the notebook to be run from root user.")
+    _i18n("Allow the notebook to be run from root user.")
 )
 
 aliases.update({
@@ -120,7 +120,7 @@ class NotebookApp(
 
     name = 'notebook'
     version = __version__
-    description = _("""The Jupyter HTML Notebook.
+    description = _i18n("""The Jupyter HTML Notebook.
 
     This launches a Tornado based HTML Notebook Server that serves up an HTML5/Javascript Notebook client.""")
 
@@ -144,7 +144,7 @@ class NotebookApp(
     ).tag(config=True)
 
     static_custom_path = List(Unicode(),
-        help=_("""Path to search for custom.js, css""")
+        help=_i18n("""Path to search for custom.js, css""")
     )
 
     @default('static_custom_path')
@@ -156,7 +156,7 @@ class NotebookApp(
         ]
 
     extra_nbextensions_path = List(Unicode(), config=True,
-        help=_("""extra paths to look for Javascript notebook extensions""")
+        help=_i18n("""extra paths to look for Javascript notebook extensions""")
     )
 
     @property
@@ -194,9 +194,9 @@ class NotebookApp(
     def initialize_settings(self):
         """Add settings to the tornado app."""
         if self.ignore_minified_js:
-            self.log.warning(_("""The `ignore_minified_js` flag is deprecated and no longer works."""))
-            self.log.warning(_("""Alternatively use `%s` when working on the notebook's Javascript and LESS""") % 'npm run build:watch')
-            warnings.warn(_("The `ignore_minified_js` flag is deprecated and will be removed in Notebook 6.0"), DeprecationWarning)
+            self.log.warning(_i18n("""The `ignore_minified_js` flag is deprecated and no longer works."""))
+            self.log.warning(_i18n("""Alternatively use `%s` when working on the notebook's Javascript and LESS""") % 'npm run build:watch')
+            warnings.warn(_i18n("The `ignore_minified_js` flag is deprecated and will be removed in Notebook 6.0"), DeprecationWarning)
 
         settings = dict(
             static_custom_path=self.static_custom_path,

--- a/nbclassic/traits.py
+++ b/nbclassic/traits.py
@@ -9,7 +9,7 @@ from notebook import (
     __version__,
 )
 from jupyter_core.paths import jupyter_path
-from jupyter_server.transutils import _
+from jupyter_server.transutils import _i18n
 from jupyter_server.utils import url_path_join
 
 
@@ -17,16 +17,16 @@ class NotebookAppTraits(HasTraits):
 
     ignore_minified_js = Bool(False,
             config=True,
-            help=_('Deprecated: Use minified JS file or not, mainly use during dev to avoid JS recompilation'),
+            help=_i18n('Deprecated: Use minified JS file or not, mainly use during dev to avoid JS recompilation'),
             )
 
 
     jinja_environment_options = Dict(config=True,
-            help=_("Supply extra arguments that will be passed to Jinja environment."))
+            help=_i18n("Supply extra arguments that will be passed to Jinja environment."))
 
     jinja_template_vars = Dict(
         config=True,
-        help=_("Extra variables to supply to jinja templates when rendering."),
+        help=_i18n("Extra variables to supply to jinja templates when rendering."),
     )
 
     enable_mathjax = Bool(True, config=True,
@@ -59,7 +59,7 @@ class NotebookAppTraits(HasTraits):
         return self.extra_static_paths + [DEFAULT_STATIC_FILES_PATH]
 
     static_custom_path = List(Unicode(),
-        help=_("""Path to search for custom.js, css""")
+        help=_i18n("""Path to search for custom.js, css""")
     )
 
     @default('static_custom_path')
@@ -71,7 +71,7 @@ class NotebookAppTraits(HasTraits):
         ]
 
     extra_template_paths = List(Unicode(), config=True,
-        help=_("""Extra paths to search for serving jinja templates.
+        help=_i18n("""Extra paths to search for serving jinja templates.
 
         Can be used to override templates from notebook.templates.""")
     )
@@ -82,7 +82,7 @@ class NotebookAppTraits(HasTraits):
         return self.extra_template_paths + DEFAULT_TEMPLATE_PATH_LIST
 
     extra_nbextensions_path = List(Unicode(), config=True,
-        help=_("""extra paths to look for Javascript notebook extensions""")
+        help=_i18n("""extra paths to look for Javascript notebook extensions""")
     )
 
     @property
@@ -124,15 +124,15 @@ class NotebookAppTraits(HasTraits):
             # enable_mathjax=False overrides mathjax_url
             self.mathjax_url = u''
         else:
-            self.log.info(_("Using MathJax: %s"), new)
+            self.log.info(_i18n("Using MathJax: %s"), new)
 
     mathjax_config = Unicode("TeX-AMS-MML_HTMLorMML-full,Safe", config=True,
-        help=_("""The MathJax.js configuration file that is to be used.""")
+        help=_i18n("""The MathJax.js configuration file that is to be used.""")
     )
 
     @observe('mathjax_config')
     def _update_mathjax_config(self, change):
-        self.log.info(_("Using MathJax configuration file: %s"), change['new'])
+        self.log.info(_i18n("Using MathJax configuration file: %s"), change['new'])
 
     quit_button = Bool(True, config=True,
         help="""If True, display a button in the dashboard to quit
@@ -140,7 +140,7 @@ class NotebookAppTraits(HasTraits):
     )
 
     nbserver_extensions = Dict({}, config=True,
-        help=(_("Dict of Python modules to load as notebook server extensions."
+        help=(_i18n("Dict of Python modules to load as notebook server extensions."
               "Entry values can be used to enable and disable the loading of"
               "the extensions. The extensions will be loaded in alphabetical "
               "order."))

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup_args = dict(
     python_requires='>=3.6',
     include_package_data=True,
     install_requires = [
-        'jupyter_server~=1.4',
+        'jupyter_server~=1.5',
         'notebook<7',
     ],
     entry_points = {


### PR DESCRIPTION
I am seing this warning when starting JupyterLab since a couple of days:
```
lib/python3.9/site-packages/jupyter_server/transutils.py:13: FutureWarning: The alias `_()` will be deprecated. Use `_i18n()` instead.
```

I am not sure nbclassic is the culprit here, but I guess it's worth doing it anyway