### PR TITLE
patch server's sorted_extensions to prioritize nbclassic

### DIFF
--- a/nbclassic/nbserver.py
+++ b/nbclassic/nbserver.py
@@ -66,6 +66,23 @@ def _link_jupyter_server_extension(serverapp):
     manager = serverapp.extension_manager
     logger = serverapp.log
 
+    # Hack that patches the enabled extensions list, prioritizing
+    # jupyter nbclassic. In the future, it would be much better
+    # to incorporate a dependency injection system in the
+    # Extension manager that allows extensions to list
+    # their dependency tree and sort that way.
+    def sorted_extensions(self):
+        """Dictionary with extension package names as keys
+        and an ExtensionPackage objects as values.
+        """
+        # Sort the keys and
+        keys = sorted(self.extensions.keys())
+        keys.remove("nbclassic")
+        keys = ["nbclassic"] + keys
+        return {key: self.extensions[key] for key in keys}
+
+    manager.__class__.sorted_extensions = property(sorted_extensions)
+
     # Look to see if nbclassic is enabled. if so,
     # link the nbclassic extension here to load
     # its config. Then, port its config to the serverapp


### PR DESCRIPTION
This reverts #49. (@minrk)

nbclassic's [nbserver](https://github.com/jupyterlab/nbclassic/blob/master/nbclassic/nbserver.py) server extension attempts to load classic server extensions (found in the old server config locations) with the new jupyter server. 

It's critical that nbclassic be loaded *before* these extensions to ensure that nbclassic's `NotebookApp` class is initialized. because some of these server extensions might try to set traits on NotebookApp (that weren't ported+shimmed to ServerApp). 

An example: [jupyter_nbexetensions_configurator](https://github.com/Jupyter-contrib/jupyter_nbextensions_configurator) sets  `nbextensions_path`, a trait in the classic NotebookApp. Nbclassic should pick up this trait, but can't if it's not initialized. 

This depends on jupyter-server/jupyter_server#522, so we should wait to merge until jupyter_server merges and releases.