### PR TITLE
bump jupyter_server dependency to 1.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup_args = dict(
     python_requires='>=3.6',
     include_package_data=True,
     install_requires = [
-        'jupyter_server~=1.5',
+        'jupyter_server~=1.8',
         'notebook<7',
     ],
     entry_points = {


### PR DESCRIPTION
#56 requires jupyter_server>=1.8. 

This needs to be merged before we release nbclassic. 
