### PR TITLE
ensure extension name is passed to TerminalHandler

### DIFF
--- a/nbclassic/notebookapp.py
+++ b/nbclassic/notebookapp.py
@@ -252,7 +252,7 @@ class NotebookApp(
         ujoin = url_path_join
         # Add terminal handlers
         static_handlers.append(
-            (ujoin(base_url, r"/terminals/(\w+)"), TerminalHandler)
+            (ujoin(base_url, r"/terminals/(\w+)"), TerminalHandler, {"name": self.name})
         )
         static_handlers.append(
             # (r"/nbextensions/(?!nbextensions_configurator\/list)(.*)", FileFindHandler, {

--- a/nbclassic/tests/test_notebookapp.py
+++ b/nbclassic/tests/test_notebookapp.py
@@ -37,3 +37,10 @@ async def test_notebook_handler(notebooks, jp_fetch):
         assert "Kernel" in html
         assert nbpath in html
 
+
+async def test_terminal_handler(jp_fetch):
+        r = await jp_fetch('terminals', "1")
+        assert r.code == 200
+        # Check that the terminals template is loaded
+        html = r.body.decode()
+        assert "terminal-app" in html


### PR DESCRIPTION
server app patches-in extension name to mixin handlers on self.handlers, but these are not on self.handlers anymore.

As a result, terminals pages cannot be accessed after #63